### PR TITLE
Support Apple M1

### DIFF
--- a/mac/install.sh
+++ b/mac/install.sh
@@ -26,7 +26,7 @@ info "Show hidden files in Finder…"
 defaults write com.apple.finder "AppleShowAllFiles" -bool true && killall Finder
 
 info "Show file extensions in Finder…"
-defaults write -globalDomain "AppleShowAllExtensions" -bool true && killall Finder
+defaults write -globalDomain "AppleShowAllExtensions" -bool true
 
 info "Show path bar…"
 defaults write com.apple.finder "ShowPathbar" -bool "true"
@@ -43,7 +43,7 @@ defaults write com.apple.dock "mru-spaces" -bool "false"
 
 # Dock
 info "Auto-hide dock…"
-defaults write com.apple.dock "autohide" -bool true && killall Dock
+defaults write com.apple.dock "autohide" -bool true
 
 info "Don't show recent apps in dock…"
 defaults write com.apple.dock "show-recents" -bool false && killall Dock

--- a/neovim/nvim.symlink/init.vim
+++ b/neovim/nvim.symlink/init.vim
@@ -1,7 +1,7 @@
 """" pre-config
-let g:ruby_path = '/usr/bin/ruby'                  " do not travers $PATH to find ruby
-let g:python_host_prog = '/usr/bin/python'         " do not mess with pyenv here
-let g:python3_host_prog = '/usr/local/bin/python3' " do not mess with pyenv here
+let g:ruby_path = '/usr/bin/ruby'                   " do not travers $PATH to find ruby
+let g:python_host_prog = '/usr/bin/python'          " do not mess with pyenv here
+let g:python3_host_prog = '/usr/bin/python3'        " do not mess with pyenv here
 
 """"""
 """ plugins

--- a/neovim/nvim.symlink/init.vim
+++ b/neovim/nvim.symlink/init.vim
@@ -10,22 +10,22 @@ call plug#begin()
 Plug 'iCyMind/NeoSolarized'
 Plug 'morhetz/gruvbox'
 
-Plug 'mileszs/ack.vim'                           " use Ack / the silversearcher
-Plug '/usr/local/opt/fzf'                        " fzf executable
-Plug 'junegunn/fzf.vim'                          " additional fzf things
-Plug 'tpope/vim-commentary'                      " shortcuts for commenting in/out
-Plug 'bogado/file-line'                          " open files directly at line number
-Plug 'tpope/vim-eunuch'                          " helpful unix shell commands
-Plug 'janko-m/vim-test'                          " run tests from within vim
-Plug 'benmills/vimux'                            " interact with tmux (e.g. for running tests)
-Plug 'tpope/vim-endwise'                         " for automatically adding 'ends' in ruby
-Plug 'machakann/vim-highlightedyank'             " blink-highlight what gets yanked
-Plug 'editorconfig/editorconfig-vim'             " accept editorconfig files
-Plug 'pmeinhardt/hmm'                            " joblogs
+Plug 'mileszs/ack.vim'                              " use Ack / the silversearcher
+Plug 'junegunn/fzf', { 'do': { -> fzf#install() } } " fzf executable
+Plug 'junegunn/fzf.vim'                             " additional fzf things
+Plug 'tpope/vim-commentary'                         " shortcuts for commenting in/out
+Plug 'bogado/file-line'                             " open files directly at line number
+Plug 'tpope/vim-eunuch'                             " helpful unix shell commands
+Plug 'janko-m/vim-test'                             " run tests from within vim
+Plug 'benmills/vimux'                               " interact with tmux (e.g. for running tests)
+Plug 'tpope/vim-endwise'                            " for automatically adding 'ends' in ruby
+Plug 'machakann/vim-highlightedyank'                " blink-highlight what gets yanked
+Plug 'editorconfig/editorconfig-vim'                " accept editorconfig files
+Plug 'pmeinhardt/hmm'                               " joblogs
 
 Plug 'Shougo/deoplete.nvim', { 'do': ':UpdateRemotePlugins' }
-Plug 'SirVer/ultisnips'                          " snippets
-Plug 'dense-analysis/ale'                        " linting
+Plug 'SirVer/ultisnips'                             " snippets
+Plug 'dense-analysis/ale'                           " linting
 
 Plug 'tonekk/vim-binding-pry',        { 'for': 'ruby' }
 Plug 'slim-template/vim-slim',        { 'for': 'slim' }
@@ -40,77 +40,77 @@ call plug#end()
 """"""
 """ general
 """"""
-let mapleader="\<Space>"                         " map leader key to space
-let maplocalleader="\<Space>"                    " map leader key to space
-set encoding=utf8                                " alwyas use utf8 encoding
-set clipboard=unnamedplus                        " use the system clipboard
-set autowriteall                                 " automatically write buffers when switching focus
-set undofile                                     " keep an undo file in the default location
-set mouse=nv                                     " enable mouse in normal and visual modei to stay compatible with tmux scrolling
-set noemoji                                      " do not assume all emoji are double width
+let mapleader="\<Space>"                            " map leader key to space
+let maplocalleader="\<Space>"                       " map leader key to space
+set encoding=utf8                                   " alwyas use utf8 encoding
+set clipboard=unnamedplus                           " use the system clipboard
+set autowriteall                                    " automatically write buffers when switching focus
+set undofile                                        " keep an undo file in the default location
+set mouse=nv                                        " enable mouse in normal and visual modei to stay compatible with tmux scrolling
+set noemoji                                         " do not assume all emoji are double width
 
 """" indentation
-set tabstop=2                                    " real tabs are 2 spaces
-set softtabstop=2                                " soft tabs are 2 spaces
-set shiftwidth=2                                 " auto-indent with 2 spaces
-set expandtab                                    " convert tabs to spaces (softtabs)
+set tabstop=2                                       " real tabs are 2 spaces
+set softtabstop=2                                   " soft tabs are 2 spaces
+set shiftwidth=2                                    " auto-indent with 2 spaces
+set expandtab                                       " convert tabs to spaces (softtabs)
 
 """" searching
-set ignorecase                                   " search case insensitive by default
-set smartcase                                    " search case sensitive when using mixed letters
-set inccommand=nosplit                           " show substitution 'live' in all places
+set ignorecase                                      " search case insensitive by default
+set smartcase                                       " search case sensitive when using mixed letters
+set inccommand=nosplit                              " show substitution 'live' in all places
 
 """ spelling
-autocmd FileType gitcommit setlocal spell        " spell check commit messages
-autocmd BufRead,BufNewFile *.md setlocal spell   " spell check markdown files
-autocmd BufRead,BufNewFile *.txt setlocal spell  " spell check text files
-set complete+=kspell                             " autocomplete words
+autocmd FileType gitcommit setlocal spell           " spell check commit messages
+autocmd BufRead,BufNewFile *.md setlocal spell      " spell check markdown files
+autocmd BufRead,BufNewFile *.txt setlocal spell     " spell check text files
+set complete+=kspell                                " autocomplete words
 
 """" window
-set scrolloff=2                                  " start scrolling w lines before the end of the screen
-set nowrap                                       " do not wrap lines
-set noshowcmd                                    " do not show the command history
-set number                                       " show line numbers
-set cursorline                                   " highlight cursor line
-set splitbelow                                   " horizontally split down by default
-set splitright                                   " vertically split to the right by default
+set scrolloff=2                                     " start scrolling w lines before the end of the screen
+set nowrap                                          " do not wrap lines
+set noshowcmd                                       " do not show the command history
+set number                                          " show line numbers
+set cursorline                                      " highlight cursor line
+set splitbelow                                      " horizontally split down by default
+set splitright                                      " vertically split to the right by default
 
 """ statusline
-set statusline=                                  " reset left side of the statusline
-set statusline+=%r\                              " show readonly flag
-set statusline+=%t\                              " show file name
-set statusline+=%m                               " show modfied flag
-set statusline+=%=                               " reset right side of the statusline
-set statusline+=%l:%c\                           " show cursor position
+set statusline=                                     " reset left side of the statusline
+set statusline+=%r\                                 " show readonly flag
+set statusline+=%t\                                 " show file name
+set statusline+=%m                                  " show modfied flag
+set statusline+=%=                                  " reset right side of the statusline
+set statusline+=%l:%c\                              " show cursor position
 
 """ netrw tree view
-let g:netrw_dirhistmax=0                         " disable history
-let g:netrw_banner = 0                           " remove banner on top
+let g:netrw_dirhistmax=0                            " disable history
+let g:netrw_banner = 0                              " remove banner on top
 
 """ colors
-set colorcolumn=80,120                           " highlight column at 80 and 120 characters
-set termguicolors                                " use true colors
-set background=dark                              " use a dark background
+set colorcolumn=80,120                              " highlight column at 80 and 120 characters
+set termguicolors                                   " use true colors
+set background=dark                                 " use a dark background
 colorscheme NeoSolarized
-let g:neosolarized_vertSplitBgTrans = 1          " transparent split bars
+let g:neosolarized_vertSplitBgTrans = 1             " transparent split bars
 
 """ markdown
-au FileType markdown setlocal wrap               " wrap lines in markdown files
+au FileType markdown setlocal wrap                  " wrap lines in markdown files
 hi! link markdownItalic Italic
 hi! link markdownBold Bold
 let g:markdown_fenced_languages = ['bash=sh', 'ruby', 'elixir', 'json', 'html']
-let g:markdown_folding = 1                       " enable folding sections on headers in markdown files
-au FileType markdown setlocal foldlevel=99       " start with folds open
+let g:markdown_folding = 1                          " enable folding sections on headers in markdown files
+au FileType markdown setlocal foldlevel=99          " start with folds open
 
 """ plugin settings
-let test#strategy = "vimux"                      " run tests in tmux split
-let g:mix_format_on_save = 1                     " autoformat elixir code
-let g:deoplete#enable_at_startup = 1             " enable deoplete autocompletion
-let g:ackprg = 'ag --vimgrep --smart-case'       " use the silversearch for Ack
-au BufRead,BufNewFile Brewfile setfiletype ruby  " use ruby syntax in brewfiles
-let g:ale_sign_error = '!'                       " character for ale linter errors
-let g:ale_sign_warning = '~'                     " character for ale linter warnings
-let g:ale_fix_on_save = 1                        " automatically fix lint errors on save
+let test#strategy = "vimux"                         " run tests in tmux split
+let g:mix_format_on_save = 1                        " autoformat elixir code
+let g:deoplete#enable_at_startup = 1                " enable deoplete autocompletion
+let g:ackprg = 'ag --vimgrep --smart-case'          " use the silversearch for Ack
+au BufRead,BufNewFile Brewfile setfiletype ruby     " use ruby syntax in brewfiles
+let g:ale_sign_error = '!'                          " character for ale linter errors
+let g:ale_sign_warning = '~'                        " character for ale linter warnings
+let g:ale_fix_on_save = 1                           " automatically fix lint errors on save
 let g:ale_fixers = {
   \ 'javascript': ['prettier', 'eslint'],
   \ 'javascriptreact': ['prettier', 'eslint']
@@ -164,5 +164,5 @@ nnoremap <silent><ESC> :noh<return><ESC>
 
 """ commands
 command FormatJSON %!jq .
-command German :set spelllang=de                 " set spellcheck language to German
-command English :set spelllang=en                " set language to English
+command German :set spelllang=de                    " set spellcheck language to German
+command English :set spelllang=en                   " set language to English

--- a/script/install
+++ b/script/install
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Install topics
+# Usage: script/install [topic]
+
 set -o errexit
 set -o nounset
 set -o pipefail
@@ -27,8 +30,14 @@ function install_topic() {
     | while read -r symlink; do $symlink; done
 }
 
-info "INSTALL TOPICS…"
-install_topic "$DOTS_DIR/homebrew"
-for topic in ${TOPICS[*]}; do
-  install_topic "$topic"
-done
+if [ $# -lt 1 ]; then
+  info "INSTALL TOPICS…"
+  install_topic "$DOTS_DIR/homebrew"
+  for topic in ${TOPICS[*]}; do
+    install_topic "$topic"
+  done
+else
+  info "INSTALL $1…"
+  install_topic "$DOTS_DIR/$1"
+fi
+

--- a/zsh/zprofile.symlink
+++ b/zsh/zprofile.symlink
@@ -1,0 +1,3 @@
+if [ "$(uname -m)" = "arm64" ]; then
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+fi

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -13,22 +13,15 @@ export HOMEBREW_BUNDLE_NO_LOCK=1                        # disable lockfile for b
 # PATH
 typeset -U PATH path                                    # make PATH an array with unique entries
 export PATH="$HOME/dotfiles/bin:$PATH"                  # dotfiles bin
-export PATH="/usr/local/bin:$PATH"                      # homebrew bin
-export PATH="/usr/local/sbin:$PATH"                     # homebrew sbin
-export PATH="/usr/local/opt/openssl/bin:$PATH"          # add openssl
+export PATH="/usr/local/opt/openssl/bin:$PATH"          # add openssl from Homebrew
 
-# completion
+# configure completion
 zstyle ':completion:*' list-colors ''                   # use LSCOLORS list colors for completion
 zstyle ':completion:*' special-dirs true                # complete the . and .. special directories
 zstyle ':completion:*:*:*:*:*' menu select              # show completion as menu and navigate with arrow keys
 zstyle ':completion:*' squeeze-slashes true             # treat multiple slashes as multiple directories
 zstyle ':completion:*' use-cache yes                    # cache completion
 zstyle ':completion:*' cache-path $HOME/.zcompcache     # completion cache directory
-
-# TODO: speed this up by only loading every 24h
-# https://gist.github.com/ctechols/ca1035271ad134841284
-autoload -Uz compinit && compinit -d $HOME/.zcompdump   # load completion
-autoload bashcompinit && bashcompinit                   # load bash completion
 
 # histoy
 HISTFILE=$HOME/.zsh_history
@@ -52,8 +45,10 @@ bindkey -e                                              # emacs keybindings
 bindkey "${terminfo[kcbt]}" reverse-menu-complete       # shift-tab for reverse completion menu
 
 # tools
-source $HOME/.asdf/asdf.sh                              # asdf
-source $HOME/.asdf/completions/asdf.bash                # asdf completion
+if [ -f "$HOME/.asdf/asdf.sh" ]; then                   # asdf
+  source $HOME/.asdf/asdf.sh
+  fpath=(${ASDF_DIR}/completions $fpath)
+fi
 [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh                  # fzf
 if which pyenv > /dev/null; then                        # pyenv
   eval "$(pyenv init - zsh --no-rehash)";
@@ -107,6 +102,12 @@ fi
 fpath+=$ZSH_DIR/plugins/pure
 autoload -U promptinit; promptinit
 prompt pure
+
+# init completion
+# TODO: speed this up by only loading every 24h
+# https://gist.github.com/ctechols/ca1035271ad134841284
+autoload -Uz compinit && compinit -d $HOME/.zcompdump   # load completion
+autoload bashcompinit && bashcompinit                   # load bash completion
 
 # plugins
 source $ZSH_DIR/plugins/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh


### PR DESCRIPTION
Some updates to support Apple's M1 chip (ARM architecture):

- Update neovim providers
- Update fzf installation for Neovim
- Fix macOS install script
- Add zprofile to zsh
- Update zsh completion and path config
- Update install script

Note: some Homebrew formulas aren't ready for M1 yet (e.g. `shellcheck` 😿)
