### PR TITLE
Fix initial setup scenario

### DIFF
--- a/fzf/install
+++ b/fzf/install
@@ -9,6 +9,7 @@ set -o pipefail
 
 source "../script/lib/utils"
 
+use_brew
 brew install fzf
 
 info "Install fzf key bindings and completion…"

--- a/homebrew/install
+++ b/homebrew/install
@@ -13,11 +13,11 @@ source "$SCRIPT_DIR/../script/lib/utils"
 
 if ! command -v brew >/dev/null; then
   info "Install homebrew…"
-  /usr/bin/env bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  yes "" | INTERACTIVE=1 /usr/bin/env bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
   if [ "$(uname -m)" = "arm64" ]; then
     info "Initialize homebrew shell…"
-    eval "$(/opt/homebrew/bin/brew shellenv)"
+    use_brew
   fi
 else
   info "Update homebrew…"

--- a/script/lib/utils
+++ b/script/lib/utils
@@ -72,3 +72,7 @@ function create_symlinks() {
     symlink "$src" "$dest"
   done
 }
+
+function use_brew() {
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+}

--- a/script/setup
+++ b/script/setup
@@ -20,4 +20,7 @@ info "Set name to '$name'…"
 sudo scutil --set ComputerName "$name"
 sudo scutil --set LocalHostName "$name"
 
+info "Create ~/.config directory if it does not exist…"
+mkdir -p ~/.config
+
 "$SCRIPT_DIR/install"

--- a/zsh/install
+++ b/zsh/install
@@ -9,6 +9,8 @@ set -o pipefail
 
 source "../script/lib/utils"
 
+use_brew
+
 HOMEBREW_ZSH="$(brew --prefix)/bin/zsh"
 readonly HOMEBREW_ZSH
 


### PR DESCRIPTION
Some fixes to problems I ran into on a new initial setup:

- Homebrew has a new install script… It requires TTY, so it's hard to
  run it from another script.

- With Homebrew not loaded into the shell via the zprofile file, it's
  not available in the other topics further down the line. Manually
  loading it with the `use_brew` helper should fix this

- On brand new machines, the `~/.config` directory may not exist, which
  breaks symlinking there. So create it as part of the `setup` script
